### PR TITLE
45 | BH | fix pagination state

### DIFF
--- a/client/src/pages/JobsList.tsx
+++ b/client/src/pages/JobsList.tsx
@@ -38,6 +38,13 @@ export default function JobsList({ source }: { source: string }) {
     fetchJobs();
   }, [page, source]);
 
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: "auto",
+    });
+  }, [page]);
+
   if (loading) {
     return (
       <div className="min-h-screen bg-gruvbox-bg flex items-center justify-center">
@@ -56,7 +63,7 @@ export default function JobsList({ source }: { source: string }) {
 
   return (
     <div className="min-h-screen bg-gruvbox-bg">
-      <section className="max-w-6xl mx-auto px-6 py-12">
+      <section className="max-w-6xl mx-auto px-6 pb-12">
         <div className="space-y-6">
           {jobs.length > 0 ? (
             jobs.map((job) => <JobsListItemRow key={job._id} job={job} />)

--- a/client/src/pages/JobsList.tsx
+++ b/client/src/pages/JobsList.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { Loader2 } from "lucide-react";
 import type { JobsListItem } from "../types/job";
 import JobsListItemRow from "../components/jobs/JobsListItemRow";
@@ -7,13 +8,10 @@ export default function JobsList({ source }: { source: string }) {
   const [jobs, setJobs] = useState<JobsListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
 
-  useEffect(() => {
-    setPage(1);
-    setError(null);
-  }, [source]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const page = parseInt(searchParams.get("page") || "1", 10);
+  const [totalPages, setTotalPages] = useState<number>(1);
 
   useEffect(() => {
     async function fetchJobs() {
@@ -44,6 +42,13 @@ export default function JobsList({ source }: { source: string }) {
       behavior: "auto",
     });
   }, [page]);
+
+  const handlePageChange = (newPage: number) => {
+    setSearchParams((prev) => {
+      prev.set("page", String(newPage));
+      return prev;
+    });
+  };
 
   if (loading) {
     return (
@@ -78,7 +83,7 @@ export default function JobsList({ source }: { source: string }) {
           <div className="flex justify-center gap-4 mt-12">
             <button
               type="button"
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              onClick={() => handlePageChange(Math.max(1, page - 1))}
               disabled={page === 1}
               className="px-6 py-2 bg-gruvbox-bg2 text-gruvbox-fg0 rounded-lg disabled:opacity-40 hover:bg-gruvbox-bg3 transition"
             >
@@ -89,7 +94,7 @@ export default function JobsList({ source }: { source: string }) {
             </span>
             <button
               type="button"
-              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              onClick={() => handlePageChange(Math.min(totalPages, page + 1))}
               disabled={page === totalPages}
               className="px-6 py-2 bg-gruvbox-bg2 text-gruvbox-fg0 rounded-lg disabled:opacity-40 hover:bg-gruvbox-bg3 transition"
             >


### PR DESCRIPTION
**_Turns out it's not a state issue._**

**What's happening:** 
When clicking the next/previous btns, the browser was not saving these actions in th route history (because they dont belong to the route), so when clicking the browser back button, we got unexpected results.

**Fix:** 
Implemented `useSearchParams` React hook to include the pagination state in the route as query params.