### PR TITLE
52 | BH | Fix Scraper Fields

### DIFF
--- a/client/src/components/jobs/LinkedInJobListItem.tsx
+++ b/client/src/components/jobs/LinkedInJobListItem.tsx
@@ -10,11 +10,11 @@ export default function LinkedInJobListItem({
   const [showDetails, setShowDetails] = useState(false);
   const [locationOpen, setLocationOpen] = useState(true);
 
-  const company = job.company ?? "Unknown Company";
-  const descriptionText = job.job_description ?? "No description provided";
+  const company = job.companyName ?? "Unknown Company";
+  const descriptionText = job.text ?? "No description provided";
   const displayDescription = `<p>${descriptionText.replace(/\n/g, "</p><p>")}</p>`;
   const locations = job.location ? [job.location] : [];
-  const datePosted = job.posted_date;
+  const datePosted = job.datePosted;
 
   return (
     <div className="job-card">
@@ -29,7 +29,7 @@ export default function LinkedInJobListItem({
           <h3
             className={`text-2xl font-bold text-gruvbox-fg0 mb-1 ${showDetails ? "" : "line-clamp-2"}`}
           >
-            {job.job_title}
+            {job.title}
           </h3>
           <p className="text-gruvbox-orange_light text-lg font-medium">
             {company}
@@ -113,7 +113,7 @@ export default function LinkedInJobListItem({
       <div className="flex items-center justify-between mt-2 pt-4 border-t border-gruvbox-bg3/50">
         <span className="text-sm text-gruvbox-gray">Posted: {datePosted}</span>
         <a
-          href={job.linkedin_url}
+          href={job.url}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-block px-6 py-2 bg-gruvbox-orange hover:bg-gruvbox-orange_light text-white rounded-lg transition font-semibold"

--- a/client/src/types/linkedinJob.ts
+++ b/client/src/types/linkedinJob.ts
@@ -3,11 +3,14 @@
  */
 export interface LinkedInJobApiResponse {
   _id: string;
-  job_title: string;
-  company?: string;
+  title: string;
+  companyName?: string;
+  companyLinkedInUrl?: string;
   location?: string;
-  job_description?: string;
-  linkedin_url: string;
-  posted_date: string;
+  text?: string;
+  url: string;
+  datePosted: string;
+  applicantCount?: string;
+  benefits?: string;
   source?: "linkedin";
 }

--- a/linkedin_scraper/linkedin_scraper/models/job.py
+++ b/linkedin_scraper/linkedin_scraper/models/job.py
@@ -10,17 +10,17 @@ class Job(BaseModel):
     
     Represents a job posting on LinkedIn with all scraped data.
     """
-    linkedin_url: str
-    job_title: Optional[str] = None
-    company: Optional[str] = None
-    company_linkedin_url: Optional[str] = None
+    url: str
+    title: Optional[str] = None
+    companyName: Optional[str] = None
+    CompanyLinkedInUrl: Optional[str] = None
     location: Optional[str] = None
-    posted_date: Optional[str] = None
-    applicant_count: Optional[str] = None
-    job_description: Optional[str] = None
+    datePosted: Optional[str] = None
+    applicantCount: Optional[str] = None
+    text: Optional[str] = None
     benefits: Optional[str] = None
     
-    @field_validator('linkedin_url')
+    @field_validator('url')
     @classmethod
     def validate_linkedin_url(cls, v: str) -> str:
         """Validate that URL is a LinkedIn job URL."""
@@ -52,8 +52,8 @@ class Job(BaseModel):
     def __repr__(self) -> str:
         """String representation."""
         return (
-            f"<Job {self.job_title} at {self.company}\n"
+            f"<Job {self.title} at {self.companyName}\n"
             f"  Location: {self.location}\n"
-            f"  Posted: {self.posted_date}\n"
-            f"  Applicants: {self.applicant_count}>"
+            f"  Posted: {self.datePosted}\n"
+            f"  Applicants: {self.applicantCount}>"
         )

--- a/server/models/HNHiringJob.ts
+++ b/server/models/HNHiringJob.ts
@@ -1,38 +1,38 @@
-import mongoose, { Schema, Document } from 'mongoose';
+import mongoose, { Schema, Document } from "mongoose";
 
 // Base interface for plain job data (used in scraping logic)
 export interface HNHiringJobData {
-    by: string;
-    datePosted: string;
-    title: string;
-    text: string;
-    links: string[];
-    monthYear: string;
-    /** Always `hnhiring` for jobs scraped from hnhiring.com */
-    source: 'hnhiring';
-    companyName?: string;
-    jobTitle?: string[];
-    jobType?: string[];
-    employmentType?: string[];
-    location?: string[];
-    skills?: string[];
-    seniority?: string[];
-    salary?: string[];
-    visaSponsorship?: string[];
-    url?: string[];
+  by: string;
+  datePosted: string;
+  title: string;
+  text: string;
+  links: string[];
+  monthYear: string;
+  source: "hnhiring";
+  companyName?: string;
+  jobTitle?: string[];
+  jobType?: string[];
+  employmentType?: string[];
+  location?: string[];
+  skills?: string[];
+  seniority?: string[];
+  salary?: string[];
+  visaSponsorship?: string[];
+  url?: string[];
 }
 
 // Mongoose Document interface
 export interface IHNHiringJob extends HNHiringJobData, Document {}
 
-const HNHiringJobSchema: Schema = new Schema({
+const HNHiringJobSchema: Schema = new Schema(
+  {
     by: { type: String, required: true },
     datePosted: { type: String },
     title: { type: String },
     text: { type: String },
     links: [{ type: String }],
     monthYear: { type: String, required: true },
-    source: { type: String, default: 'hnhiring' },
+    source: { type: String, default: "hnhiring" },
     companyName: { type: String },
     jobTitle: [{ type: String }],
     jobType: [{ type: String }],
@@ -43,6 +43,11 @@ const HNHiringJobSchema: Schema = new Schema({
     salary: [{ type: String }],
     visaSponsorship: [{ type: String }],
     url: [{ type: String }],
-}, { timestamps: true });
+  },
+  { timestamps: true },
+);
 
-export const HNHiringJob = mongoose.model<IHNHiringJob>('HNHiringJob', HNHiringJobSchema);
+export const HNHiringJob = mongoose.model<IHNHiringJob>(
+  "HNHiringJob",
+  HNHiringJobSchema,
+);

--- a/server/models/LinkedInJob.ts
+++ b/server/models/LinkedInJob.ts
@@ -1,24 +1,34 @@
 import mongoose, { Schema, Document } from "mongoose";
 
 // Base interface for plain job data (used in scraping logic)
-export interface LinkedInJobDataRaw {
-  url: string;
-  title: string;
-  company?: string;
-  location?: string;
-  jobDescription?: string;
+export interface LinkedInJobData {
+  url: string; // common
+  title: string; // common
+  companyName?: string; // common
+  companyLinkedInUrl?: string;
+  location?: string; // common
+  datePosted: string; // common
+  applicantCount?: string;
+  text: string; // common
+  benefits?: string;
+  source: "linkedin";
 }
 
 // Mongoose Document interface
-export interface ILinkedInJob extends LinkedInJobDataRaw, Document {}
+export interface ILinkedInJob extends LinkedInJobData, Document {}
 
 const LinkedInJobSchema: Schema = new Schema(
   {
     url: { type: String, required: true, unique: true },
     title: { type: String, required: true },
-    company: { type: String },
+    companyName: { type: String },
+    companyLinkedInUrl: { type: String },
     location: { type: String },
-    jobDescription: { type: String },
+    datePosted: { type: String },
+    applicantCount: { type: String },
+    text: { type: String },
+    benefits: { type: String },
+    source: { type: String, default: "linkedin" },
   },
   { timestamps: true },
 );

--- a/server/tests/scripts/updateLinkedinFields.ts
+++ b/server/tests/scripts/updateLinkedinFields.ts
@@ -1,0 +1,43 @@
+import "dotenv/config";
+import mongoose, { disconnect } from "mongoose";
+import { connectDB } from "../../config/db.js";
+
+// TODO: Remove later when we make sure python linkedin scraper is adding fields correctly.
+async function renameDatabaseFields() {
+  try {
+    console.log("Connecting to database...");
+    await connectDB();
+    const db = mongoose.connection.db;
+    if (!db) {
+      throw new Error("Database connection not established");
+    }
+
+    const collection = db.collection("Jobs");
+    // Execute the rename operation
+    const result = await collection.updateMany(
+      { source: "linkedin" }, // Filter to target only LinkedIn jobs
+      {
+        $rename: {
+          linkedin_url: "url",
+          job_title: "title",
+          company: "companyName",
+          company_linkedin_url: "companyLinkedInUrl",
+          posted_date: "datePosted",
+          applicant_count: "applicantCount",
+          job_description: "text",
+        },
+      },
+    );
+
+    console.log(`Rename process was successful!`);
+    console.log(`Matched documents: ${result.matchedCount}`);
+    console.log(`Modified documents: ${result.modifiedCount}`);
+  } catch (error) {
+    console.error("Migration failed:", error);
+  } finally {
+    // Clean up connection
+    await disconnect();
+  }
+}
+
+renameDatabaseFields();


### PR DESCRIPTION
- Updated TS Models
- Updated Python LinkedIn Scraper Model
- Created and ran a script that updates MongoDB LinkedIn jobs fields. 

Changed fields (now they're in common with HN fields):
`linkedin_url -> url`
`job_title -> title`
`company -> companyName`
`company_linkedin_url -> CompanyLinkedInUrl`
`posted_date -> datePosted`
`applicant_count -> applicantCount`
`job_description -> text`
