### PR TITLE
62 | BH | Apply/Hide jobs

### DIFF
--- a/client/src/components/jobs/HnhiringJobListItem.tsx
+++ b/client/src/components/jobs/HnhiringJobListItem.tsx
@@ -1,20 +1,29 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
-import { MapPin, ChevronDown, Terminal } from "lucide-react";
+import { MapPin, ChevronDown, Terminal, Check, EyeOff } from "lucide-react";
 import type { HnhiringJobApiResponse } from "../../types/hnhiringJob";
 import { formatRelativeTime } from "../../utils/dateFormatter";
+import type { JobActions } from "./JobsListItemRow";
 
 export default function HnhiringJobListItem({
   job,
+  actions,
 }: {
   job: HnhiringJobApiResponse;
+  actions: JobActions;
 }) {
   const [showDetails, setShowDetails] = useState(false);
   const [locationOpen, setLocationOpen] = useState(true);
   const [skillsOpen, setSkillsOpen] = useState(true);
 
   return (
-    <div className="job-card">
+    <div
+      className={`job-card transition-all duration-300 ${
+        actions.isApplied
+          ? "opacity-40 pointer-events-none hover:opacity-60 [&_a]:pointer-events-auto [&_button]:pointer-events-auto"
+          : ""
+      }`}
+    >
       <div className="flex justify-between items-start mb-4">
         <div className="flex-1">
           <div className="flex items-center mb-3">
@@ -146,16 +155,45 @@ export default function HnhiringJobListItem({
         />
       </button>
 
-      <div className="flex items-center justify-between mt-2 pt-4 border-t border-gruvbox-bg3/50">
+      <div className="flex items-center justify-between mt-2 pt-4 border-t border-gruvbox-bg3/50 gap-2 flex-wrap">
         <span className="text-sm text-gruvbox-gray">
           {formatRelativeTime(job.datePosted)}
         </span>
-        <Link
-          to={`/jobs/${job._id}`}
-          className="inline-block px-6 py-2 bg-gruvbox-orange hover:bg-gruvbox-orange_light text-white rounded-lg transition font-semibold"
-        >
-          View Details
-        </Link>
+
+        <div className="flex items-center gap-2">
+          {/* Hide Button */}
+          <button
+            type="button"
+            onClick={actions.hideJob}
+            className="flex items-center gap-1.5 px-3 py-2 text-sm text-gruvbox-gray hover:text-gruvbox-fg0 bg-gruvbox-bg1 hover:bg-gruvbox-bg2 rounded-lg transition border border-gruvbox-bg3/50"
+          >
+            <EyeOff className="w-4 h-4" />
+            <span>Hide</span>
+          </button>
+
+          {/* Applied Toggle Button */}
+          <button
+            type="button"
+            onClick={actions.toggleApplied}
+            className={`flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg transition border border-gruvbox-bg3/50 ${
+              actions.isApplied
+                ? "bg-gruvbox-aqua/20 text-gruvbox-aqua_light border-gruvbox-aqua/40"
+                : "bg-gruvbox-bg1 text-gruvbox-gray hover:text-gruvbox-fg0 hover:bg-gruvbox-bg2"
+            }`}
+          >
+            <Check
+              className={`w-4 h-4 transition-transform ${actions.isApplied ? "scale-110" : ""}`}
+            />
+            <span>{actions.isApplied ? "Applied" : "Mark Applied"}</span>
+          </button>
+
+          <Link
+            to={`/jobs/${job._id}`}
+            className="inline-block px-6 py-2 bg-gruvbox-orange hover:bg-gruvbox-orange_light text-white rounded-lg transition font-semibold text-sm"
+          >
+            View Details
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/jobs/JobsListItemRow.tsx
+++ b/client/src/components/jobs/JobsListItemRow.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import type { JobsListItem } from "../../types/job";
 import {
   isHnhiringJobApiResponse,
@@ -7,11 +8,79 @@ import HnhiringJobListItem from "./HnhiringJobListItem";
 import LinkedInJobListItem from "./LinkedInJobListItem";
 
 export default function JobsListItemRow({ job }: { job: JobsListItem }) {
+  const [isApplied, setIsApplied] = useState<boolean>(() => {
+    try {
+      const saved = localStorage.getItem("appliedJobIds");
+      const parsed: string[] = saved ? JSON.parse(saved) : [];
+      return parsed.includes(job._id);
+    } catch {
+      return false;
+    }
+  });
+
+  const [isHidden, setIsHidden] = useState<boolean>(() => {
+    try {
+      const saved = localStorage.getItem("hiddenJobIds");
+      const parsed: string[] = saved ? JSON.parse(saved) : [];
+      return parsed.includes(job._id);
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem("appliedJobIds");
+      let currentIds: string[] = saved ? JSON.parse(saved) : [];
+
+      if (isApplied) {
+        if (!currentIds.includes(job._id)) currentIds.push(job._id);
+      } else {
+        currentIds = currentIds.filter((id) => id !== job._id);
+      }
+      localStorage.setItem("appliedJobIds", JSON.stringify(currentIds));
+    } catch (error) {
+      console.error("Error updating localStorage for applied jobs:", error);
+    }
+  }, [isApplied, job._id]);
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem("hiddenJobIds");
+      let currentIds: string[] = saved ? JSON.parse(saved) : [];
+
+      if (isHidden) {
+        if (!currentIds.includes(job._id)) currentIds.push(job._id);
+      } else {
+        currentIds = currentIds.filter((id) => id !== job._id);
+      }
+      localStorage.setItem("hiddenJobIds", JSON.stringify(currentIds));
+    } catch (error) {
+      console.error("Error updating localStorage for hidden jobs:", error);
+    }
+  }, [isHidden, job._id]);
+
+  if (isHidden) {
+    return null;
+  }
+
+  const clientActions = {
+    isApplied,
+    toggleApplied: () => setIsApplied((prev) => !prev),
+    hideJob: () => setIsHidden(true),
+  };
+
   if (isHnhiringJobApiResponse(job)) {
-    return <HnhiringJobListItem job={job} />;
+    return <HnhiringJobListItem job={job} actions={clientActions} />;
   }
   if (isLinkedInJobApiResponse(job)) {
-    return <LinkedInJobListItem job={job} />;
+    return <LinkedInJobListItem job={job} actions={clientActions} />;
   }
   return null;
+}
+
+export interface JobActions {
+  isApplied: boolean;
+  toggleApplied: () => void;
+  hideJob: () => void;
 }

--- a/client/src/components/jobs/JobsListItemRow.tsx
+++ b/client/src/components/jobs/JobsListItemRow.tsx
@@ -1,5 +1,8 @@
 import type { JobsListItem } from "../../types/job";
-import { isHnhiringJobApiResponse, isLinkedInJobApiResponse } from "../../types/job";
+import {
+  isHnhiringJobApiResponse,
+  isLinkedInJobApiResponse,
+} from "../../types/job";
 import HnhiringJobListItem from "./HnhiringJobListItem";
 import LinkedInJobListItem from "./LinkedInJobListItem";
 
@@ -8,7 +11,7 @@ export default function JobsListItemRow({ job }: { job: JobsListItem }) {
     return <HnhiringJobListItem job={job} />;
   }
   if (isLinkedInJobApiResponse(job)) {
-  return <LinkedInJobListItem job={job} />;
+    return <LinkedInJobListItem job={job} />;
   }
   return null;
 }

--- a/client/src/components/jobs/LinkedInJobListItem.tsx
+++ b/client/src/components/jobs/LinkedInJobListItem.tsx
@@ -1,12 +1,15 @@
 import { useState } from "react";
-import { MapPin, ChevronDown, Globe } from "lucide-react";
+import { MapPin, ChevronDown, Globe, Check, EyeOff } from "lucide-react";
 import type { LinkedInJobApiResponse } from "../../types/linkedinJob";
 import { formatRelativeTime } from "../../utils/dateFormatter";
+import type { JobActions } from "./JobsListItemRow";
 
 export default function LinkedInJobListItem({
   job,
+  actions,
 }: {
   job: LinkedInJobApiResponse;
+  actions: JobActions;
 }) {
   const [showDetails, setShowDetails] = useState(false);
   const [locationOpen, setLocationOpen] = useState(true);
@@ -18,7 +21,13 @@ export default function LinkedInJobListItem({
   const datePosted = job.datePosted;
 
   return (
-    <div className="job-card">
+    <div
+      className={`job-card transition-all duration-300 ${
+        actions.isApplied
+          ? "opacity-40 pointer-events-none hover:opacity-60 [&_a]:pointer-events-auto [&_button]:pointer-events-auto"
+          : ""
+      }`}
+    >
       <div className="flex justify-between items-start mb-4">
         <div className="flex-1">
           <div className="flex items-center mb-3">
@@ -111,18 +120,47 @@ export default function LinkedInJobListItem({
         />
       </button>
 
-      <div className="flex items-center justify-between mt-2 pt-4 border-t border-gruvbox-bg3/50">
+      <div className="flex items-center justify-between mt-2 pt-4 border-t border-gruvbox-bg3/50 gap-2 flex-wrap">
         <span className="text-sm text-gruvbox-gray">
           {formatRelativeTime(datePosted)}
         </span>
-        <a
-          href={job.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-block px-6 py-2 bg-gruvbox-orange hover:bg-gruvbox-orange_light text-white rounded-lg transition font-semibold"
-        >
-          Apply Now
-        </a>
+
+        <div className="flex items-center gap-2">
+          {/* Hide Button */}
+          <button
+            type="button"
+            onClick={actions.hideJob}
+            className="flex items-center gap-1.5 px-3 py-2 text-sm text-gruvbox-gray hover:text-gruvbox-fg0 bg-gruvbox-bg1 hover:bg-gruvbox-bg2 rounded-lg transition border border-gruvbox-bg3/50"
+          >
+            <EyeOff className="w-4 h-4" />
+            <span>Hide</span>
+          </button>
+
+          {/* Applied Toggle Button */}
+          <button
+            type="button"
+            onClick={actions.toggleApplied}
+            className={`flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg transition border border-gruvbox-bg3/50 ${
+              actions.isApplied
+                ? "bg-gruvbox-aqua/20 text-gruvbox-aqua_light border-gruvbox-aqua/40"
+                : "bg-gruvbox-bg1 text-gruvbox-gray hover:text-gruvbox-fg0 hover:bg-gruvbox-bg2"
+            }`}
+          >
+            <Check
+              className={`w-4 h-4 transition-transform ${actions.isApplied ? "scale-110" : ""}`}
+            />
+            <span>{actions.isApplied ? "Applied" : "Mark Applied"}</span>
+          </button>
+
+          <a
+            href={job.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block px-6 py-2 bg-gruvbox-orange hover:bg-gruvbox-orange_light text-white rounded-lg transition font-semibold"
+          >
+            Apply Now
+          </a>
+        </div>
       </div>
     </div>
   );

--- a/server/data/hnhiring_first_title.txt
+++ b/server/data/hnhiring_first_title.txt
@@ -1,1 +1,1 @@
-june-2026|SEEKING WORK | Poland / EU | Remote CET | Senior Full Stack Developer
+june-2026|SafetyWing (YC W18) | Partnerships Manager | 100% Remote | Hiring Globally


### PR DESCRIPTION
Implemented the following:
- Hide job (currently cannot be undone except by deleting job id from local storage). We can add undo later on the user page, for example.
- Mark jobs applied will fade out but stay shown. Can be undone.

We can enhance the UI later.